### PR TITLE
Fixed issue with title and description needing the ReverseEndian button

### DIFF
--- a/ForgeMapViewer/Forge Map Viewer/Forge Map Viewer/frmMain.cs
+++ b/ForgeMapViewer/Forge Map Viewer/Forge Map Viewer/frmMain.cs
@@ -18,6 +18,7 @@ namespace Forge_Map_Viewer
         const int MapDescOffset    = 0x1C0;
         const int MapDescLen       = 0x130;
 
+        byte offset;
         byte[] fmap;
         byte[] mapTitleSection;
         byte[] mapDescSection;
@@ -54,15 +55,24 @@ namespace Forge_Map_Viewer
 
             if (HeaderValid(fmap))
             {
+                //find offset
+                if (fmap[MapTitleOffset] == 0)
+                {
+                    offset = 0x1;
+                }
+                else
+                {
+                    offset = 0x0;
+                }
                 //process map title string
-                mapTitleSection = fmap.Skip(MapTitleOffset).Take(MapTitleLen).ToArray();
+                mapTitleSection = fmap.Skip(MapTitleOffset + offset).Take(MapTitleLen).ToArray();
 
                 string mapTitle = string.Empty;
                 for (int ii = 0; ii < MapTitleLen; ii += 2)
                     mapTitle += BitConverter.ToChar(mapTitleSection, ii);
 
                 //process map description string
-                mapDescSection = fmap.Skip(MapDescOffset).Take(MapDescLen).ToArray();
+                mapDescSection = fmap.Skip(MapDescOffset + offset).Take(MapDescLen).ToArray();
 
                 string mapDesc = string.Empty;
                 for (int ii = 0; ii < MapDescLen; ii += 2)


### PR DESCRIPTION
I'm not sure if you're still working on this but I found that this works with the maps I have. The title and description seems to be offset by 1 character sometimes. Not sure why the offset happens but the changes I submitted made it so I don't need to use the ReverseEndian button on any of my maps. I'd like confirmation that this works on your end too.