### PR TITLE
Ability to read map and game types from multiple games

### DIFF
--- a/ForgeMapViewer/Forge Map Viewer/Forge Map Viewer/Classes/BinaryArray.cs
+++ b/ForgeMapViewer/Forge Map Viewer/Forge Map Viewer/Classes/BinaryArray.cs
@@ -1,0 +1,187 @@
+﻿using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Collections;
+
+namespace Forge_Map_Viewer.Classes
+{
+    /// <summary>
+    /// Wrapper class for bit array that holds bits from bytes from most significant to least significant (reverse of BitArray) which allows easy bit shifting
+    /// </summary>
+    public class BinaryArray
+    {
+        /// <summary>
+        /// The BitArray that holds all the bits
+        /// </summary>
+        BitArray bitArray;
+        /// <summary>
+        /// Create a binary array from byte array 
+        /// </summary>
+        /// <param name="bytes">Bytes to be turned into an array</param>
+        public BinaryArray(byte[] bytes)
+        {
+            FromByteArray(bytes);
+        }
+        /// <summary>
+        /// Set bits from a array of bytes
+        /// </summary>
+        /// <param name="bytes">The byte array to be set from</param>
+        public void FromByteArray(byte[] bytes)
+        {
+            if (bytes != null && bytes.Length > 0)
+            {
+                byte[] singleByte = new byte[1] { bytes[0] };
+                BitArray singleByteArray;
+                List<bool> bits = new List<bool>();
+                for (int i = 0; i < bytes.Length; i++)
+                {
+                    singleByte[0] = bytes[i];
+                    singleByteArray = new BitArray(singleByte);
+                    for (int j = 7; j >= 0; j--)
+                    {
+                        bits.Add(singleByteArray[j]);
+                    }
+                }
+                bitArray = new BitArray(bits.Count);
+                for (int i = 0; i < bits.Count; i++)
+                {
+                    bitArray[i] = bits[i];
+                }
+            }
+        }
+        /// <summary>
+        /// Copy bits to a byte array
+        /// </summary>
+        /// <returns>Bits as a byte array</returns>
+        public byte[] CopyToByteArray()
+        {
+            if (bitArray.Count % 8 != 0) throw new Exception("Amount of bits in BitArray is not evenly divisable by 8 and can't be turned into bytes properly");
+            if (bitArray.Count == 0) return new byte[0]; // if count is 0 the exception will not be thrown but the rest of the function shouldn't be preformed
+            byte[] returnValue = new byte[bitArray.Count / 8];
+            int currentByte;
+            int currentBit;
+            for (int i = 0; i < returnValue.Length; i++)
+            {
+                currentByte = 0;
+                for (int j = 0; j < 8; j++)
+                {
+                    currentByte = currentByte << 1; //does nothing when j = 0 otherwise shifts bits left and sets last bit to 0
+                    currentBit = bitArray[i * 8 + j] ? 1 : 0; //get bit from array
+                    currentByte = currentByte | currentBit; //set least significant bit
+                }
+                returnValue[i] = Convert.ToByte(currentByte); //add completed byte to the return value array
+            }
+            return returnValue;
+        }
+        /// <summary>
+        /// Gets bit at a specified index as a bool
+        /// </summary>
+        /// <param name="index">Index of byte</param>
+        /// <returns>Bit as a bool</returns>
+        public bool this[int index]
+        {
+            get => bitArray[index];
+            set => bitArray[index] = value;
+        }
+        /// <summary>
+        /// Shifts bits right by a specified amount
+        /// </summary>
+        /// <param name="shiftAmount">How much to shift</param>
+        /// <param name="replaceWith">What to set on the left side of the array</param>
+        /// <returns>Overflow bits as a bool array</returns>
+        public bool[] ShiftRight(int shiftAmount, bool replaceWith = false)
+        {
+            int bitArrayCount = bitArray.Count;
+            List<bool> returnValue = new List<bool>(); // holds overflow data
+            if (shiftAmount == 0) return returnValue.ToArray(); // No shift
+            else if (shiftAmount >= bitArrayCount) // Shift all the bits out
+            {
+                for (int i = 0; i < bitArrayCount; i++)
+                {
+                    returnValue.Add(bitArray[i]);
+                    bitArray[i] = replaceWith;
+                }
+            }
+            else //shift some bits 
+            {
+                for (int i = 0; i < shiftAmount; i++)
+                {
+                    //collect overflow data
+                    returnValue.Add(bitArray[bitArrayCount - shiftAmount + i]);
+                }
+                for (int i = bitArrayCount - shiftAmount - 1; i >= 0; i--)
+                {
+                    //shift bits
+                    bitArray[i + shiftAmount] = bitArray[i];
+                }
+                for (int i = 0; i < shiftAmount; i++)
+                {
+                    //replace bits at the start
+                    bitArray[i] = replaceWith;
+                }
+            }
+            return returnValue.ToArray();
+        }
+        /// <summary>
+        /// Shifts bits left by a specified amount
+        /// </summary>
+        /// <param name="shiftAmount">How much to shift</param>
+        /// <param name="replaceWith">What to set on the right side of the array</param>
+        /// <returns>Overflow bits as a bool array</returns>
+        public bool[] ShiftLeft(int shiftAmount, bool replaceWith = false)
+        {
+            int bitArrayCount = bitArray.Count;
+            List<bool> returnValue = new List<bool>(); // holds overflow data
+            if (shiftAmount == 0) return returnValue.ToArray(); // No shift
+            else if (shiftAmount >= bitArrayCount) // Shift all the bits out
+            {
+                for (int i = 0; i < bitArrayCount; i++)
+                {
+                    returnValue.Add(bitArray[i]);
+                    bitArray[i] = replaceWith;
+                }
+            }
+            else //shift some bits 
+            {
+                for (int i = 0; i < shiftAmount; i++)
+                {
+                    //collect overflow data
+                    returnValue.Add(bitArray[i]);
+                }
+                for (int i = shiftAmount; i < bitArrayCount; i++)
+                {
+                    //shift bits
+                    bitArray[i - shiftAmount] = bitArray[i];
+                }
+                for (int i = bitArrayCount - shiftAmount; i < bitArrayCount; i++)
+                {
+                    //replace bits at the end
+                    bitArray[i] = replaceWith;
+                }
+            }
+            return returnValue.ToArray();
+        }
+        /// <summary>
+        /// Gets binary representation of array as a string of 1s and 0s with a space between each byte
+        /// </summary>
+        /// <returns>Returns array as a string of 1s and 0s with a space between each byte</returns>
+        public override string ToString()
+        {
+            string bitsString = "";
+            for (int i = 0, bits = 0; i < bitArray.Count; i++)
+            {
+                bitsString += bitArray[i] ? "1" : "0";
+                bits++;
+                if (bits >= 8)
+                {
+                    bits = 0;
+                    bitsString += " ";
+                }
+            }
+            return bitsString;
+        }
+    }
+}

--- a/ForgeMapViewer/Forge Map Viewer/Forge Map Viewer/Classes/FileInfo.cs
+++ b/ForgeMapViewer/Forge Map Viewer/Forge Map Viewer/Classes/FileInfo.cs
@@ -1,0 +1,312 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Forge_Map_Viewer.Classes
+{
+    /// <summary>
+    /// Gets and holds in game name and description from map and game type files
+    /// </summary>
+    public class FileInfo
+    {
+        #region Fields
+        /// <summary>
+        /// In game name of file
+        /// </summary>
+        public string InGameName = "";
+        /// <summary>
+        /// In game description of file
+        /// </summary>
+        public string Description = "";
+        /// <summary>
+        /// Game file is from
+        /// </summary>
+        public enum Game
+        {
+            HaloReach,
+            HaloCE,
+            Halo2Classic,
+            Halo2Anniversary,
+            Halo3,
+            Halo3ODST,
+            Halo4
+        }
+        #endregion
+        #region Constructors
+        /// <summary>
+        /// Creates an instance from strings 
+        /// </summary>
+        /// <param name="inGameName">In game name</param>
+        /// <param name="description">In game description</param>
+        public FileInfo(string inGameName = "", string description = "")
+        {
+            InGameName = inGameName ?? "";
+            Description = description ?? "";
+        }
+        /// <summary>
+        /// Creates an instance from a file 
+        /// </summary>
+        /// <param name="file">The file to be read</param>
+        /// <param name="game">The game the file is from</param>
+        public FileInfo(string file, Game game)
+        {
+            FileInfo info = GetFileInfo(file, game);
+            InGameName = info.InGameName;
+            Description = info.Description;
+        }
+        #endregion
+        #region Functions
+        /// <summary>
+        /// The name and description seperated by a new line character
+        /// </summary>
+        /// <returns>The name and description seperated by a new line character</returns>
+        public override string ToString()
+        {
+            return InGameName + "\n" + Description;
+        }
+        /// <summary>
+        /// Turns a byte array into a string 16 bit characters and removes any null characters
+        /// </summary>
+        /// <param name="bytes">Character bytes</param>
+        /// <returns>String version of bytes as 16 bit characters without any null characters</returns>
+        static string GetStringOf16BitCharacters(byte[] bytes)
+        {
+            string returnValue = "";
+            char currentChar;
+            //16 bit chars shouldn't have remainder but if so assume the bit at the start is a null byte
+            for (int i = bytes.Length % 2 == 0 ? 0 : 1; i < bytes.Length; i += 2)
+            {
+                currentChar = BytesTo16BitChar(bytes[i], bytes[i + 1]);//get current char
+                returnValue += currentChar == 0 ? "" : currentChar.ToString(); //add if not null
+            }
+            return returnValue;
+        }
+        /// <summary>
+        /// Turns a byte array into a string of 8 bit characters without any null characters
+        /// </summary>
+        /// <param name="bytes">Character bytes</param>
+        /// <returns>String version of bytes as 8 bit characters without any null characters</returns>
+        static string GetStringOf8BitCharacters(byte[] bytes)
+        {
+            string returnValue = "";
+            char currentChar;
+            for (int i = 0; i < bytes.Length; i++)
+            {
+                currentChar = (char)bytes[i];//get current char
+                returnValue += currentChar == 0 ? "" : currentChar.ToString(); //add if not null
+            }
+            return returnValue;
+        }
+        /// <summary>
+        /// Gets in game name and description as an array of bytes from a byte array where the name and description are seperated by null bytes
+        /// </summary>
+        /// <param name="input">File as byte array</param>
+        /// <param name="startingByte">Where the in game name starts</param>
+        /// <param name="name">The array where the in game name will be stored</param>
+        /// <param name="description">The array where the in game description will be stored</param>
+        /// <param name="has16BitDescription">Is the description 16 byte characters?</param>
+        /// <param name="maxBytesToParse">How many bytes the function should parse before returning incomplete</param>
+        static void GetNameAndDescriptionBytes(byte[] input, int startingByte, out byte[] name, out byte[] description, bool has16BitDescription = true, int maxBytesToParse = 512)
+        {
+            int nullBytesInARow = 0;
+            int stoppingByte = startingByte + maxBytesToParse;
+            if (stoppingByte > input.Length) stoppingByte = input.Length;
+            int endOfName = 0;
+            int startOfDescription = 0;
+            int endOfDescription = 0;
+            name = new byte[0];
+            description = new byte[0];
+            for (int i = startingByte; i < stoppingByte; i++)
+            {
+                if (input[i] == 0) //null byte
+                {
+                    nullBytesInARow++;
+                    if (nullBytesInARow == 2)//space between or end of name or description
+                    {
+                        if (endOfName == 0) //found end of name
+                        {
+                            endOfName = i;
+                            name = input.Skip(startingByte).Take(endOfName - startingByte + 1).ToArray();
+                        }
+                        else if (startOfDescription != 0) //found end of description
+                        {
+                            endOfDescription = i;
+                            description = input.Skip(startOfDescription).Take(endOfDescription - startOfDescription - 1).ToArray();
+                            return;
+                        }
+                    }
+                }
+                else if (name.Length != 0 && startOfDescription == 0) //found start of description
+                {
+                    nullBytesInARow = 0;
+                    startOfDescription = i;
+                    if (has16BitDescription) startOfDescription--; //stored as 16 bit char so will usually need the null that came before if it's A-z or 0-9
+                }
+                else //non null byte
+                {
+                    nullBytesInARow = 0;
+                }
+            }
+        }
+        /// <summary>
+        /// Gets in game name and description as an array of bytes from a byte array where the name and description are at specific points in the file
+        /// </summary>
+        /// <param name="input">File as byte array</param>
+        /// <param name="nameStartByte">Where the in game name starts</param>
+        /// <param name="name">The array where the in game name will be stored</param>
+        /// <param name="descriptionStartByte">Where the in game description starts</param>
+        /// <param name="description">The array where the in game description will be stored</param>
+        /// <param name="maxBytesToParse">How many bytes the function should parse before returning incomplete</param>
+        static void GetNameAndDescriptionBytes(byte[] input, int nameStartByte, out byte[] name, int descriptionStartByte, out byte[] description, int maxBytesToParse = 512)
+        {
+            int nullBytesInARow = 0;
+            int stoppingByte = nameStartByte + maxBytesToParse;
+            if (stoppingByte > input.Length) stoppingByte = input.Length;
+            int endOfName = 0;
+            name = new byte[0];
+            for (int i = nameStartByte; i < stoppingByte; i++)
+            {
+                if (input[i] == 0) //null byte
+                {
+                    nullBytesInARow++;
+                    if (nullBytesInARow >= 2)//space between or end of name or description
+                    {
+                        if (endOfName == 0) //found end of name
+                        {
+                            endOfName = i;
+                            name = input.Skip(nameStartByte).Take(endOfName - nameStartByte - 1).ToArray();
+                            break;
+                        }
+                    }
+                }
+                else //non null byte
+                {
+                    nullBytesInARow = 0;
+                }
+            }
+            stoppingByte = descriptionStartByte + maxBytesToParse;
+            if (stoppingByte > input.Length) stoppingByte = input.Length;
+            nullBytesInARow = 0;
+            int endOfDescription = 0;
+            description = new byte[0];
+            for (int i = descriptionStartByte; i < stoppingByte; i++)
+            {
+                if (input[i] == 0) //null byte
+                {
+                    nullBytesInARow++;
+                    if (nullBytesInARow >= 2)//space between or end of name or description
+                    {
+                        endOfDescription = i;
+                        description = input.Skip(descriptionStartByte).Take(endOfDescription - descriptionStartByte - 1).ToArray();
+                        break;
+                    }
+                }
+                else //non null byte
+                {
+                    nullBytesInARow = 0;
+                }
+            }
+        }
+        /// <summary>
+        /// Safely gets a 16 bit character from 2 bytes
+        /// </summary>
+        /// <param name="byte1">First byte of character</param>
+        /// <param name="byte2">Second byte of character</param>
+        /// <returns>Character version of the two bytes</returns>
+        static char BytesTo16BitChar(byte byte1, byte byte2)
+        {
+            try
+            {
+                return (char)((byte1 << 8) | byte2);
+            }
+            catch { return (char)0; }
+        }
+        /// <summary>
+        /// Gets in game name and description as strings from a file
+        /// </summary>
+        /// <param name="file">File to be read</param>
+        /// <param name="game">Game the file is from</param>
+        /// <returns>Returns FileInfo class with in game name and description as strings. If the name and or description can't be read the strings will be empty</returns>
+        static FileInfo GetFileInfo(string file, Game game)
+        {
+            FileInfo returnInfo = new FileInfo();
+            if (file != null && File.Exists(file) && Path.GetExtension(file) == ".bin" || Path.GetExtension(file) == ".mvar")
+            {
+                byte[] fileBytes = File.ReadAllBytes(file);
+                byte[] name = new byte[0];
+                byte[] description = new byte[0];
+                switch (game)
+                {
+                    case Game.HaloReach:
+                        int offset = fileBytes[192] == 0 ? 1 : 0;
+                        GetNameAndDescriptionBytes(fileBytes, 191 + offset, out name, 447 + offset, out description);
+                        return new FileInfo(GetStringOf16BitCharacters(name), GetStringOf16BitCharacters(description));
+                    case Game.HaloCE:
+                        GetNameAndDescriptionBytes(fileBytes, 151, out name, 407, out description);
+                        return new FileInfo(GetStringOf16BitCharacters(name), GetStringOf16BitCharacters(description));
+                    case Game.Halo2Classic:
+                        GetNameAndDescriptionBytes(fileBytes, 303, out name, 559, out description);
+                        return new FileInfo(GetStringOf16BitCharacters(name), GetStringOf16BitCharacters(description));
+                    case Game.Halo2Anniversary:
+                        if (Path.GetExtension(file) == ".bin")
+                        {
+                            GetNameAndDescriptionBytes(fileBytes, 191, out name, 447, out description);
+                            return new FileInfo(GetStringOf16BitCharacters(name), GetStringOf16BitCharacters(description));
+                        }
+                        else
+                        {
+                            //maps bit shifted 2 left. Description next to name
+                            GetNameAndDescriptionBytes(fileBytes, 161, out name, out description);
+                            BinaryArray binaryArray = new BinaryArray(name);
+                            binaryArray.ShiftRight(2);
+                            returnInfo.InGameName = GetStringOf16BitCharacters(binaryArray.CopyToByteArray());
+                            binaryArray = new BinaryArray(description);
+                            binaryArray.ShiftRight(2);
+                            returnInfo.Description = GetStringOf16BitCharacters(binaryArray.CopyToByteArray());
+                            return returnInfo;
+                        }
+                    case Game.Halo3:
+                        //check if built in file
+                        offset = 0;
+                        string builtInTextCheck = "";
+                        for (int i = 14; i < 25; i++)
+                        {
+                            builtInTextCheck += (char)fileBytes[i];
+                        }
+                        //check of built in map or game type
+                        if (builtInTextCheck == "game var\0\0\0")
+                        {
+                            //abort cant read built in game var 
+                            Console.WriteLine("Unable to obtain built in Halo 3 game type name and description. Path:" + file);
+                            return new FileInfo("Unable to obtain game name", "Unable to obtain description");
+                        }
+                        else if (builtInTextCheck == "map variant")
+                        {
+                            //built in map var, add offset
+                            offset = -188;
+                        }
+                        int startName = 336;
+                        if (Path.GetExtension(file) == ".bin")
+                        {
+                            startName = 343;
+                        }
+                        if (fileBytes[startName + offset + 1] == 0) { offset++; } //check if info is shifted by 1 if so adjust offset
+                        GetNameAndDescriptionBytes(fileBytes, startName + offset, out name, out description, false);
+                        returnInfo = new FileInfo(GetStringOf16BitCharacters(name), GetStringOf8BitCharacters(description));
+                        return returnInfo;
+                    case Game.Halo3ODST:
+                        //Not implemented yet
+                        break;
+                    case Game.Halo4:
+                        GetNameAndDescriptionBytes(fileBytes, 192, out name, 448, out description);
+                        return new FileInfo(GetStringOf16BitCharacters(name), GetStringOf16BitCharacters(description));
+                }
+            }
+            return returnInfo;
+        }
+        #endregion
+    }
+}

--- a/ForgeMapViewer/Forge Map Viewer/Forge Map Viewer/Forge Map Viewer.csproj
+++ b/ForgeMapViewer/Forge Map Viewer/Forge Map Viewer/Forge Map Viewer.csproj
@@ -49,6 +49,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Classes\BinaryArray.cs" />
+    <Compile Include="Classes\FileInfo.cs" />
     <Compile Include="frmMain.cs">
       <SubType>Form</SubType>
     </Compile>


### PR DESCRIPTION
This should allow the reading of map and game type variant files from:
- Halo: Reach
- Halo CE
- Halo 2: Classic
- Halo 2: Anniversary
- Halo 3
- Halo 4

This pull request doesn't implement it into the UI because I'm not sure exactly how you would like to implement it. I'm not sure how to determine which game the file is from without user input so you might need a combo box or something to tell what game the file is for. 
Use the FileInfo class with 
`FileInfo info = new FileInfo("C:\examplePath.mvar" , FileInfo.Game.HaloReach);`
It will pull the info and you can get the in game name and description with `info.InGameName` and `info.Description`

Halo 2 Anniversary map variants are a pain to get the name and description from and require bit shifting which is why I made the **BinaryArray** class. The BitArray class that comes out of the box will put bytes into the array least significant bit first (right to left) so the **BinaryArray** class just wraps it and makes puts bytes in most significant bit first (left to right).